### PR TITLE
feat: 글 작성, 수정 페이지에서는 Control 컴포넌트 가리기

### DIFF
--- a/src/app/Control.tsx
+++ b/src/app/Control.tsx
@@ -1,12 +1,16 @@
 'use client'
 import Link from 'next/link'
-import { useParams, useRouter } from 'next/navigation'
+import { useParams, useRouter, usePathname } from 'next/navigation'
 
 export const Control = () => {
   const params = useParams()
   const id = params.id
 
   const router = useRouter()
+
+  const pathReg = /(create|update)/
+  const currentPath = usePathname()
+  const isShowControl = currentPath.match(pathReg) ? false : true
 
   const onDeletePost = async () => {
     const options = { method: 'DELETE' }
@@ -22,20 +26,26 @@ export const Control = () => {
   }
 
   return (
-    <ul>
-      <li className="border-sky-500 hover:bg-sky-500 border-2 rounded-full text-center text-sm px-4 py-0.5 mb-2">
-        <Link href="/create"> 글쓰기 </Link>
-      </li>
-      {id && (
-        <>
-          <li className="border-green-500 hover:bg-green-500 border-2 rounded-full text-center text-sm px-4 py-0.5 mb-2">
-            <Link href={`/update/${id}`}> 수정하기 </Link>
+    <>
+      {isShowControl ? (
+        <ul>
+          <li className="border-sky-500 hover:bg-sky-500 border-2 rounded-full text-center text-sm px-4 py-0.5 mb-2">
+            <Link href="/create"> 글쓰기 </Link>
           </li>
-          <li className="border-rose-500 hover:bg-rose-500  border-2 rounded-full text-center text-sm px-4 py-0.5 mb-2">
-            <input type="button" value="삭제하기" onClick={onDeletePost} />
-          </li>
-        </>
+          {id && (
+            <>
+              <li className="border-green-500 hover:bg-green-500 border-2 rounded-full text-center text-sm px-4 py-0.5 mb-2">
+                <Link href={`/update/${id}`}> 수정하기 </Link>
+              </li>
+              <li className="border-rose-500 hover:bg-rose-500  border-2 rounded-full text-center text-sm px-4 py-0.5 mb-2">
+                <input type="button" value="삭제하기" onClick={onDeletePost} />
+              </li>
+            </>
+          )}
+        </ul>
+      ) : (
+        <></>
       )}
-    </ul>
+    </>
   )
 }


### PR DESCRIPTION
## 👩‍💻 작업 내용
* #21 
  
  * `RootLayout` 에서 가리고 싶었는데 `usePathname`이 클라이언트 컴포넌트 전용이라 `Control`에서 삼항 연산자로 나눴음 🤔

## ✨ 실행 화면
![image](https://github.com/nijuy/nextjs-practice/assets/87255462/b368ad61-029e-4183-af40-df4597af731d)
![image](https://github.com/nijuy/nextjs-practice/assets/87255462/094d059f-a71f-485f-82f6-0b7a031fe6a6)
